### PR TITLE
Potential fix for code scanning alert no. 1: Semicolon insertion

### DIFF
--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -263,7 +263,7 @@ describe('AddUserComponent', () => {
       addUserComponent.addUserForm.get(controlName).setErrors({'unknown': true});
       expect(addUserComponent.getErrorMessage(controlName)).toEqual('Unknown error');
     });
-  })
+  });
 });
 
 describe('AddUserComponent#submitForm()', () => {


### PR DESCRIPTION
Potential fix for [https://github.com/UMM-CSci-3601/3601-iteration-template-from-subrepos/security/code-scanning/1](https://github.com/UMM-CSci-3601/3601-iteration-template-from-subrepos/security/code-scanning/1)

To fix the problem, we need to add an explicit semicolon at the end of the block on line 266. This will ensure that the code adheres to the convention of using explicit semicolons and avoids any potential issues related to automatic semicolon insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
