### PR TITLE
Fix the Dockerfile in server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,4 +20,4 @@ ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait
 RUN chmod +x /wait
 
 # Run the server when the container is started
-CMD ["/wait", "server/bin/server"]
+CMD /wait && server/bin/server


### PR DESCRIPTION
This commit essentially reverts part of a commit in the 3601-iteration-template repository where I followed a DeepSource suggestion without fully understanding what it was doing. a0d16c1f6154e3bab6c70cbbe67c5ae9f2a78e16 

-----------------
DeepSource tells me:
When using the plain text version of passing arguments, signals from the OS are not correctly passed to the executables, which is in the majority of the cases what you would expect.

These points shall always be taken care of:

CMD should almost always be used in the form of CMD [“executable”, “param1”, “param2”…] The shell form prevents any CMD or run command line arguments from being used, but has the disadvantage that your ENTRYPOINT will be started as a subcommand of /bin/sh -c, which does not pass signals. This means that the executable will not be the container’s PID 1 - and will not receive Unix signals - so your executable will not receive a SIGTERM from docker stop .

Read more about these best practices here: https://docs.docker.com/build/building/best-practices/